### PR TITLE
Add `just` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ allowing usage of this library in server side (or Flutter) projects as well.
     .sample
     .scan
     .startWith
+    .startWithMany
     .takeUntil
     .timeInterval
     .tap
@@ -38,6 +39,7 @@ allowing usage of this library in server side (or Flutter) projects as well.
     
  /// the following are contructors
  new Observable
+    .just
     .combineLatest (deprecated - see below)
     .concat
     .merge

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -177,6 +177,12 @@ abstract class Observable<T> extends Stream<T> {
   factory Observable.fromIterable(Iterable<T> data) =>
       observable((new Stream<T>.fromIterable(data)));
 
+  /// Creates an Observable that contains a single value
+  ///
+  /// The value is emitted when the stream receives a listener.
+  factory Observable.just(T data) =>
+      observable((new Stream<T>.fromIterable(<T>[data])));
+
   /// Creates an Observable that gets its data from [stream].
   ///
   /// If stream throws an error, the Observable ends immediately with

--- a/test/observable/just_test.dart
+++ b/test/observable/just_test.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart' as rx;
+
+void main() {
+  test('rx.Observable.just', () async {
+    const int value = 1;
+
+    Stream<int> observable = new rx.Observable<int>.just(value);
+
+    observable.listen(expectAsync1((int actual) {
+      expect(actual, value);
+    }, count: 1));
+  });
+}

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -5,6 +5,7 @@ import 'observable/combine_latest_test.dart' as combine_latest_test;
 import 'observable/concat_test.dart' as concat_test;
 import 'observable/merge_test.dart' as merge_test;
 import 'observable/zip_test.dart' as zip_test;
+import 'observable/just_test.dart' as just_test;
 
 import 'operators/debounce_test.dart' as debounce_test;
 import 'operators/throttle_test.dart' as throttle_test;
@@ -34,6 +35,7 @@ void main() {
   concat_test.main();
   merge_test.main();
   zip_test.main();
+  just_test.main();
 
   debounce_test.main();
   throttle_test.main();


### PR DESCRIPTION
I've found myself doing `new Observable.fromIterable(<int>[1])` a few times now, and realized I miss the `new Observable.just(1)` constructor from other Rx implementations. I know it's a simple change, but one that might be nice to have :)

Would you be open to this PR which adds the `just` constructor from the ReactiveX spec? http://reactivex.io/documentation/operators/just.html

Thanks!