### PR TITLE
Add defer factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ allowing usage of this library in server side (or Flutter) projects as well.
     .amb
     .combineLatest (deprecated - see below)
     .concat
+    .defer
     .just
     .merge
     .tween

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -6,6 +6,7 @@ import 'package:rxdart/src/observable/combine_latest.dart'
     show CombineLatestObservable;
 import 'package:rxdart/src/observable/concat.dart'
     show ConcatObservable;
+import 'package:rxdart/src/observable/defer.dart' show DeferObservable;
 import 'package:rxdart/src/observable/merge.dart' show MergeObservable;
 import 'package:rxdart/src/observable/stream.dart' show StreamObservable;
 import 'package:rxdart/src/observable/tween.dart' show TweenObservable, Ease;
@@ -153,6 +154,19 @@ abstract class Observable<T> extends Stream<T> {
   factory Observable.concat(Iterable<Stream<T>> streams,
       {bool asBroadcastStream: false}) =>
       new ConcatObservable<T>(streams, asBroadcastStream);
+
+  /// The defer factory waits until an observer subscribes to it, and then it
+  /// generates an Observable with the given function.
+  ///
+  /// It does this afresh for each subscriber, so although each subscriber may
+  /// think it is subscribing to the same Observable, in fact each subscriber
+  /// gets its own individual sequence.
+  ///
+  /// In some circumstances, waiting until the last minute (that is, until
+  /// subscription time) to generate the Observable can ensure that this
+  /// Observable contains the freshest data.
+  factory Observable.defer(Stream<T> create()) =>
+      new DeferObservable<T>(create);
 
   ///  Creates an Observable where all events of an existing stream are piped through
   ///  a sink-transformation.

--- a/lib/src/observable/defer.dart
+++ b/lib/src/observable/defer.dart
@@ -1,0 +1,17 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:rxdart/src/observable/stream.dart';
+
+class DeferObservable<T> extends StreamObservable<T> with ControllerMixin<T> {
+  final Create<T> create;
+
+  DeferObservable(this.create);
+
+  @override
+  StreamSubscription<T> listen(void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return observable(create()).listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+}
+
+typedef Stream<T> Create<T>();

--- a/test/observable/defer_test.dart
+++ b/test/observable/defer_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart' as rx;
+
+void main() {
+  test('rx.Observable.defer', () async {
+    const int value = 1;
+
+    Stream<int> observable = _getDeferStream();
+
+    observable.listen(expectAsync1((int actual) {
+      expect(actual, value);
+    }, count: 1));
+  });
+
+  test('rx.Observable.defer.multiple.listeners', () async {
+    const int value = 1;
+
+    Stream<int> observable = _getDeferStream();
+
+    observable.listen(expectAsync1((int actual) {
+      expect(actual, value);
+    }, count: 1));
+
+    observable.listen(expectAsync1((int actual) {
+      expect(actual, value);
+    }, count: 1));
+  });
+
+  test('rx.Observable.defer.error.shouldThrow', () async {
+    Stream<int> observableWithError =
+        new rx.Observable<int>.defer(() => _getErroneousStream());
+
+    observableWithError.listen(null,
+        onError: expectAsync1((dynamic e) {
+          expect(e, isException);
+        }, count: 1));
+  });
+}
+
+Stream<int> _getDeferStream() =>
+    new rx.Observable<int>.defer(() => new rx.Observable<int>.just(1));
+
+Stream<int> _getErroneousStream() {
+  StreamController<int> controller = new StreamController<int>();
+
+  controller.addError(new Exception());
+  controller.close();
+
+  return controller.stream;
+}


### PR DESCRIPTION
Add the `defer` factory. References part of #14.

More info about the factory: 

- http://reactivex.io/documentation/operators/defer.html
- http://blog.danlew.net/2015/07/23/deferring-observable-code-until-subscription-in-rxjava/