### PR TITLE
Rename combineNLatest and zipN to combineLatestN and zipN

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,24 +58,24 @@ allowing usage of this library in server side (or Flutter) projects as well.
  /// These methods are available as static methods, since class
  /// factory methods don't support generic method types.
  Observable
-    .combineTwoLatest
-    .combineThreeLatest
-    .combineFourLatest
-    .combineFiveLatest
-    .combineSixLatest
-    .combineSevenLatest
-    .combineEightLatest
-    .combineNineLatest
+    .combineLatest2
+    .combineLatest3
+    .combineLatest4
+    .combineLatest5
+    .combineLatest6
+    .combineLatest7
+    .combineLatest8
+    .combineLatest9
  
  Observable
-    .zipTwo
-    .zipThree
-    .zipFour
-    .zipFive
-    .zipSix
-    .zipSeven
-    .zipEight
-    .zipNine
+    .zip2
+    .zip3
+    .zip4
+    .zip5
+    .zip6
+    .zip7
+    .zip8
+    .zip9
     
  /// BehaviourSubject and ReplaySubject are available
  /// The default StreamController functions as a PublishSubject

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -36,7 +36,7 @@ abstract class Observable<T> extends Stream<T> {
   ///
   /// http://rxmarbles.com/#combineLatest
   @Deprecated(
-      'For better strong mode support, use combineTwoLatest, combineThreeLatest, ... instead')
+      'For better strong mode support, use combineLatest2, combineLatest3, ... instead')
   factory Observable.combineLatest(
           Iterable<Stream<dynamic>> streams, Function predicate,
           {bool asBroadcastStream: false}) =>
@@ -46,7 +46,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineTwoLatest<A, B, T>(
+  static Observable<T> combineLatest2<A, B, T>(
           Stream<A> streamOne, Stream<B> streamTwo, T predicate(A a, B b),
           {bool asBroadcastStream: false}) =>
       new CombineLatestObservable<T>(<Stream<dynamic>>[streamOne, streamTwo],
@@ -56,7 +56,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineThreeLatest<A, B, C, T>(
+  static Observable<T> combineLatest3<A, B, C, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -71,7 +71,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineFourLatest<A, B, C, D, T>(
+  static Observable<T> combineLatest4<A, B, C, D, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -87,7 +87,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineFiveLatest<A, B, C, D, E, T>(
+  static Observable<T> combineLatest5<A, B, C, D, E, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -107,7 +107,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineSixLatest<A, B, C, D, E, F, T>(
+  static Observable<T> combineLatest6<A, B, C, D, E, F, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -129,7 +129,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineSevenLatest<A, B, C, D, E, F, G, T>(
+  static Observable<T> combineLatest7<A, B, C, D, E, F, G, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -153,7 +153,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineEightLatest<A, B, C, D, E, F, G, H, T>(
+  static Observable<T> combineLatest8<A, B, C, D, E, F, G, H, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -179,7 +179,7 @@ abstract class Observable<T> extends Stream<T> {
   /// values from each feeder stream into the predicate function.
   ///
   /// http://rxmarbles.com/#combineLatest
-  static Observable<T> combineNineLatest<A, B, C, D, E, F, G, H, I, T>(
+  static Observable<T> combineLatest9<A, B, C, D, E, F, G, H, I, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -322,7 +322,7 @@ abstract class Observable<T> extends Stream<T> {
   ///
   /// http://rxmarbles.com/#zip
   @Deprecated(
-      'For better strong mode support, use zipTwo, zipThree, ... instead')
+      'For better strong mode support, use zip2, zip3, ... instead')
   factory Observable.zip(Iterable<Stream<dynamic>> streams, Function predicate,
           {bool asBroadcastStream: false}) =>
       new ZipObservable<T>(streams, predicate, asBroadcastStream);
@@ -340,7 +340,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipTwo<A, B, T>(
+  static Observable<T> zip2<A, B, T>(
           Stream<A> streamOne, Stream<B> streamTwo, T predicate(A a, B b),
           {bool asBroadcastStream: false}) =>
       new ZipObservable<T>(<Stream<dynamic>>[streamOne, streamTwo], predicate,
@@ -359,7 +359,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipThree<A, B, C, T>(
+  static Observable<T> zip3<A, B, C, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -381,7 +381,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipFour<A, B, C, D, T>(
+  static Observable<T> zip4<A, B, C, D, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -406,7 +406,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipFive<A, B, C, D, E, T>(
+  static Observable<T> zip5<A, B, C, D, E, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -435,7 +435,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipSix<A, B, C, D, E, F, T>(
+  static Observable<T> zip6<A, B, C, D, E, F, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -466,7 +466,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipSeven<A, B, C, D, E, F, G, T>(
+  static Observable<T> zip7<A, B, C, D, E, F, G, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -499,7 +499,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipEight<A, B, C, D, E, F, G, H, T>(
+  static Observable<T> zip8<A, B, C, D, E, F, G, H, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
@@ -534,7 +534,7 @@ abstract class Observable<T> extends Stream<T> {
   /// emitted by the source Observable that emits the fewest items.
   ///
   /// http://rxmarbles.com/#zip
-  static Observable<T> zipNine<A, B, C, D, E, F, G, H, I, T>(
+  static Observable<T> zip9<A, B, C, D, E, F, G, H, I, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,

--- a/test/benchmarks/combine_latest_benchmark.dart
+++ b/test/benchmarks/combine_latest_benchmark.dart
@@ -14,7 +14,7 @@ class CombineLatestBenchmark extends BenchmarkBase {
   @override
   void run() {
     Observable
-        .combineTwoLatest(range(), range(), (int x, int y) => x + y)
+        .combineLatest2(range(), range(), (int x, int y) => x + y)
         .listen(null);
   }
 }

--- a/test/benchmarks/zip_benchmark.dart
+++ b/test/benchmarks/zip_benchmark.dart
@@ -13,6 +13,6 @@ class ZipBenchmark extends BenchmarkBase {
 
   @override
   void run() {
-    Observable.zipTwo(range(), range(), (int x, int y) => x + y).listen(null);
+    Observable.zip2(range(), range(), (int x, int y) => x + y).listen(null);
   }
 }

--- a/test/observable/combine_latest_test.dart
+++ b/test/observable/combine_latest_test.dart
@@ -35,7 +35,7 @@ void main() {
     }, count: 3));
   });
 
-  test('rx.Observable.combineTwoLatest', () async {
+  test('rx.Observable.combineLatest2', () async {
     final List<List<int>> expected = <List<int>>[
       <int>[1, 2],
       <int>[2, 2]
@@ -45,7 +45,7 @@ void main() {
     Stream<int> a = new Observable<int>.fromIterable(<int>[1, 2]);
     Stream<int> b = new Observable<int>.just(2);
 
-    Stream<List<int>> observable = Observable.combineTwoLatest(
+    Stream<List<int>> observable = Observable.combineLatest2(
         a, b, (int first, int second) => <int>[first, second]);
 
     observable.listen(expectAsync1((List<int> result) {
@@ -53,12 +53,12 @@ void main() {
     }, count: expected.length));
   });
 
-  test('rx.Observable.combineTwoLatest.throws', () async {
+  test('rx.Observable.combineLatest2.throws', () async {
     Stream<int> a = new Observable<int>.just(1);
     Stream<int> b = new Observable<int>.just(2);
 
     Stream<List<int>> observable =
-        Observable.combineTwoLatest(a, b, (int first, int second) {
+        Observable.combineLatest2(a, b, (int first, int second) {
       throw new Exception();
     });
 
@@ -67,14 +67,14 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineThreeLatest', () async {
+  test('rx.Observable.combineLatest3', () async {
     const List<dynamic> expected = const <dynamic>[1, "2", 3.0];
 
     Stream<int> a = new Observable<int>.just(1);
     Stream<String> b = new Observable<String>.just("2");
     Stream<double> c = new Observable<double>.just(3.0);
 
-    Stream<List<dynamic>> observable = Observable.combineThreeLatest(
+    Stream<List<dynamic>> observable = Observable.combineLatest3(
         a,
         b,
         c,
@@ -86,7 +86,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineFourLatest', () async {
+  test('rx.Observable.combineLatest4', () async {
     const List<int> expected = const <int>[1, 2, 3, 4];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -94,7 +94,7 @@ void main() {
     Stream<int> c = new Observable<int>.just(3);
     Stream<int> d = new Observable<int>.just(4);
 
-    Stream<List<int>> observable = Observable.combineFourLatest(
+    Stream<List<int>> observable = Observable.combineLatest4(
         a,
         b,
         c,
@@ -107,7 +107,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineFiveLatest', () async {
+  test('rx.Observable.combineLatest5', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -116,7 +116,7 @@ void main() {
     Stream<int> d = new Observable<int>.just(4);
     Stream<int> e = new Observable<int>.just(5);
 
-    Stream<List<int>> observable = Observable.combineFiveLatest(
+    Stream<List<int>> observable = Observable.combineLatest5(
         a,
         b,
         c,
@@ -130,7 +130,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineSixLatest', () async {
+  test('rx.Observable.combineLatest6', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -140,7 +140,7 @@ void main() {
     Stream<int> e = new Observable<int>.just(5);
     Stream<int> f = new Observable<int>.just(6);
 
-    Stream<List<int>> observable = Observable.combineSixLatest(
+    Stream<List<int>> observable = Observable.combineLatest6(
         a,
         b,
         c,
@@ -155,7 +155,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineSevenLatest', () async {
+  test('rx.Observable.combineLatest7', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -166,7 +166,7 @@ void main() {
     Stream<int> f = new Observable<int>.just(6);
     Stream<int> g = new Observable<int>.just(7);
 
-    Stream<List<int>> observable = Observable.combineSevenLatest(
+    Stream<List<int>> observable = Observable.combineLatest7(
         a,
         b,
         c,
@@ -183,7 +183,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineEightLatest', () async {
+  test('rx.Observable.combineLatest8', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7, 8];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -195,7 +195,7 @@ void main() {
     Stream<int> g = new Observable<int>.just(7);
     Stream<int> h = new Observable<int>.just(8);
 
-    Stream<List<int>> observable = Observable.combineEightLatest(
+    Stream<List<int>> observable = Observable.combineLatest8(
         a,
         b,
         c,
@@ -213,7 +213,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.combineNineLatest', () async {
+  test('rx.Observable.combineLatest9', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -226,7 +226,7 @@ void main() {
     Stream<int> h = new Observable<int>.just(8);
     Stream<int> i = new Observable<int>.just(9);
 
-    Stream<List<int>> observable = Observable.combineNineLatest(
+    Stream<List<int>> observable = Observable.combineLatest9(
         a,
         b,
         c,

--- a/test/observable/tween_test.dart
+++ b/test/observable/tween_test.dart
@@ -110,7 +110,7 @@ void main() {
     int count = 0;
 
     Observable
-        .zipFour(
+        .zip4(
             new Observable<double>.tween(0.0, 100.0, const Duration(seconds: 2),
                 intervalMs: 20),
             new Observable<double>.tween(0.0, 100.0, const Duration(seconds: 2),

--- a/test/observable/zip_test.dart
+++ b/test/observable/zip_test.dart
@@ -44,7 +44,7 @@ void main() {
     Stream<int> a = new Observable<int>.fromIterable(<int>[1, 2]);
     Stream<int> b = new Observable<int>.just(2);
 
-    Stream<List<int>> observable = Observable.zipTwo(
+    Stream<List<int>> observable = Observable.zip2(
         a, b, (int first, int second) => <int>[first, second]);
 
     // Explicitly adding count: 1. It's important here, and tests the difference
@@ -55,7 +55,7 @@ void main() {
     }, count: 1));
   });
 
-  test('rx.Observable.zipThree', () async {
+  test('rx.Observable.zip3', () async {
     // Verify the ability to pass through various types with safety
     const List<dynamic> expected = const <dynamic>[1, "2", 3.0];
 
@@ -63,7 +63,7 @@ void main() {
     Stream<String> b = new Observable<String>.just("2");
     Stream<double> c = new Observable<double>.just(3.0);
 
-    Stream<List<dynamic>> observable = Observable.zipThree(
+    Stream<List<dynamic>> observable = Observable.zip3(
         a,
         b,
         c,
@@ -75,7 +75,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipFour', () async {
+  test('rx.Observable.zip4', () async {
     const List<int> expected = const <int>[1, 2, 3, 4];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -83,7 +83,7 @@ void main() {
     Stream<int> c = new Observable<int>.just(3);
     Stream<int> d = new Observable<int>.just(4);
 
-    Stream<List<int>> observable = Observable.zipFour(
+    Stream<List<int>> observable = Observable.zip4(
         a,
         b,
         c,
@@ -96,7 +96,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipFive', () async {
+  test('rx.Observable.zip5', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -105,7 +105,7 @@ void main() {
     Stream<int> d = new Observable<int>.just(4);
     Stream<int> e = new Observable<int>.just(5);
 
-    Stream<List<int>> observable = Observable.zipFive(
+    Stream<List<int>> observable = Observable.zip5(
         a,
         b,
         c,
@@ -119,7 +119,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipSix', () async {
+  test('rx.Observable.zip6', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -129,7 +129,7 @@ void main() {
     Stream<int> e = new Observable<int>.just(5);
     Stream<int> f = new Observable<int>.just(6);
 
-    Stream<List<int>> observable = Observable.zipSix(
+    Stream<List<int>> observable = Observable.zip6(
         a,
         b,
         c,
@@ -144,7 +144,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipSeven', () async {
+  test('rx.Observable.zip7', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -155,7 +155,7 @@ void main() {
     Stream<int> f = new Observable<int>.just(6);
     Stream<int> g = new Observable<int>.just(7);
 
-    Stream<List<int>> observable = Observable.zipSeven(
+    Stream<List<int>> observable = Observable.zip7(
         a,
         b,
         c,
@@ -172,7 +172,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipEight', () async {
+  test('rx.Observable.zip8', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7, 8];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -184,7 +184,7 @@ void main() {
     Stream<int> g = new Observable<int>.just(7);
     Stream<int> h = new Observable<int>.just(8);
 
-    Stream<List<int>> observable = Observable.zipEight(
+    Stream<List<int>> observable = Observable.zip8(
         a,
         b,
         c,
@@ -202,7 +202,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.zipNine', () async {
+  test('rx.Observable.zip9', () async {
     const List<int> expected = const <int>[1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     Stream<int> a = new Observable<int>.just(1);
@@ -215,7 +215,7 @@ void main() {
     Stream<int> h = new Observable<int>.just(8);
     Stream<int> i = new Observable<int>.just(9);
 
-    Stream<List<int>> observable = Observable.zipNine(
+    Stream<List<int>> observable = Observable.zip9(
         a,
         b,
         c,
@@ -253,7 +253,7 @@ void main() {
       ..add(true)
       ..close();
 
-    Stream<List<dynamic>> observable = Observable.zipThree(
+    Stream<List<dynamic>> observable = Observable.zip3(
         new Stream<int>.periodic(
             const Duration(milliseconds: 20), (int count) => count).take(4),
         new Stream<int>.fromIterable(const <int>[1, 2, 3, 4, 5, 6, 7, 8, 9]),
@@ -269,7 +269,7 @@ void main() {
   });
 
   test('rx.Observable.zip.error.shouldThrow', () async {
-    Stream<int> observableWithError = Observable.zipTwo(
+    Stream<int> observableWithError = Observable.zip2(
         new Observable<int>.just(1),
         new Observable<int>.just(2),
         (int a, int b) => throw new Exception());
@@ -282,7 +282,7 @@ void main() {
 
   test('rx.Observable.zip.pause.resume', () async {
     StreamSubscription<int> subscription;
-    Stream<int> observableWithError = Observable.zipTwo(
+    Stream<int> observableWithError = Observable.zip2(
         new Observable<int>.just(1),
         new Observable<int>.just(2),
         (int a, int b) => a + b);

--- a/web/list/list.dart
+++ b/web/list/list.dart
@@ -84,7 +84,7 @@ void main() {
       resize.map((_) => visibleRowCount()).startWith(visibleRowCount());
 
   final Observable<Map<String, int>> displayedRange =
-      Observable.combineTwoLatest(
+      Observable.combineLatest2(
           displayedIndices,
           accumulatedOffset,
           (num maxIndex, num offset) => <String, int>{
@@ -103,7 +103,7 @@ void main() {
   displayedIndices.listen(print);
 
   Observable
-      .combineTwoLatest(
+      .combineLatest2(
           displayedPeople,
           accumulatedOffset,
           (List<Person> people, num offset) =>


### PR DESCRIPTION
We'd discussed this over chat, thought I'd put it up as a real PR for consideration for consistency with packages like `test` and for developer ergonomics. 