### PR TITLE
Add onErrorResumeNext and onErrorReturn operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ allowing usage of this library in server side (or Flutter) projects as well.
     .max
     .min
     .ofType
+    .onErrorResumeNext
+    .onErrorReturn
     .repeat
     .retry
     .sample

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -19,6 +19,7 @@ import 'package:rxdart/src/transformers/interval.dart';
 import 'package:rxdart/src/transformers/max.dart';
 import 'package:rxdart/src/transformers/min.dart';
 import 'package:rxdart/src/transformers/of_type.dart';
+import 'package:rxdart/src/transformers/on_error_resume_next.dart';
 import 'package:rxdart/src/transformers/repeat.dart';
 import 'package:rxdart/src/transformers/retry.dart';
 import 'package:rxdart/src/transformers/sample.dart';
@@ -821,6 +822,23 @@ class Observable<T> extends Stream<T> {
   /// ```
   Observable<S> ofType<S>(TypeToken<S> typeToken) =>
       transform(ofTypeTransformer(typeToken));
+
+  /// Intercepts error events and switches to the given stream in that case
+  ///
+  /// The onErrorResumeNext operator intercepts an onError notification from
+  /// the source Observable. Instead of passing it through to any observers, it
+  /// replaces it with another Stream of items.
+  Observable<T> onErrorResumeNext(Stream<T> recoveryStream) =>
+      transform(onErrorResumeNextTransformer(recoveryStream));
+
+  /// instructs an Observable to emit a particular item when it encounters an
+  /// error, and then terminate normally
+  ///
+  /// The onErrorReturn operator intercepts an onError notification from
+  /// the source Observable. Instead of passing it through to any observers, it
+  /// replaces it with a given item, and then terminates normally.
+  Observable<T> onErrorReturn(T returnValue) => transform(
+      onErrorResumeNextTransformer(new Observable<T>.just(returnValue)));
 
   @override
   Future<dynamic> pipe(StreamConsumer<T> streamConsumer) =>

--- a/lib/src/transformers/on_error_resume_next.dart
+++ b/lib/src/transformers/on_error_resume_next.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+StreamTransformer<T, T> onErrorResumeNextTransformer<T>(
+    Stream<T> recoveryStream) {
+  StreamController<T> controller;
+  bool shouldCloseController = true;
+
+  void safeClose() {
+    if (shouldCloseController) {
+      controller.close();
+    }
+  }
+
+  return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    StreamSubscription<T> inputSubscription;
+    StreamSubscription<T> recoverySubscription;
+
+    controller = new StreamController<T>(
+        sync: true,
+        onListen: () {
+          inputSubscription = input.listen((T data) {
+            controller.add(data);
+          }, onError: (dynamic e, dynamic s) {
+            shouldCloseController = false;
+
+            recoverySubscription = recoveryStream.listen(controller.add,
+                onError: controller.addError,
+                onDone: controller.close,
+                cancelOnError: cancelOnError);
+
+            inputSubscription.cancel();
+          }, onDone: safeClose, cancelOnError: cancelOnError);
+        },
+        onPause: ([Future<dynamic> resumeSignal]) {
+          inputSubscription?.pause(resumeSignal);
+          recoverySubscription?.pause(resumeSignal);
+        },
+        onResume: () {
+          inputSubscription?.resume();
+          recoverySubscription?.resume();
+        },
+        onCancel: () {
+          return Future.wait(<Future<dynamic>>[
+            inputSubscription?.cancel(),
+            recoverySubscription?.cancel()
+          ]);
+        });
+
+    return controller.stream.listen(null);
+  });
+}

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -10,6 +10,7 @@ export 'package:rxdart/src/transformers/interval.dart';
 export 'package:rxdart/src/transformers/max.dart';
 export 'package:rxdart/src/transformers/min.dart';
 export 'package:rxdart/src/transformers/of_type.dart';
+export 'package:rxdart/src/transformers/on_error_resume_next.dart';
 export 'package:rxdart/src/transformers/repeat.dart';
 export 'package:rxdart/src/transformers/retry.dart';
 export 'package:rxdart/src/transformers/sample.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -44,6 +44,8 @@ import 'transformers/last_where_test.dart' as last_where_test;
 import 'transformers/max_test.dart' as max_test;
 import 'transformers/min_test.dart' as min_test;
 import 'transformers/of_type_test.dart' as of_type_test;
+import 'transformers/on_error_resume_next_test.dart' as on_error_resume_next_test;
+import 'transformers/on_error_return_test.dart' as on_error_return_test;
 import 'transformers/reduce_test.dart' as reduce_test;
 import 'transformers/repeat_test.dart' as repeat_test;
 import 'transformers/retry_test.dart' as retry_test;
@@ -117,6 +119,8 @@ void main() {
   max_test.main();
   min_test.main();
   of_type_test.main();
+  on_error_resume_next_test.main();
+  on_error_return_test.main();
   reduce_test.main();
   repeat_test.main();
   retry_test.main();

--- a/test/transformers/on_error_resume_next_test.dart
+++ b/test/transformers/on_error_resume_next_test.dart
@@ -1,0 +1,81 @@
+import '../test_utils.dart';
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+Stream<num> _getStream() {
+  return new Stream<num>.fromIterable(<num>[0, 1, 2, 3]);
+}
+
+const List<num> expected = const <num>[0, 1, 2, 3];
+
+void main() {
+  test('rx.Observable.onErrorResumeNext', () async {
+    int count = 0;
+
+    observable(getErroneousStream())
+        .onErrorResumeNext(_getStream())
+        .listen(expectAsync1((num result) {
+      expect(result, expected[count++]);
+    }, count: expected.length));
+  });
+
+  test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
+    Stream<num> stream = observable(getErroneousStream())
+        .onErrorResumeNext(_getStream())
+        .asBroadcastStream();
+    int countA = 0;
+    int countB = 0;
+
+    expect(stream.isBroadcast, isTrue);
+
+    stream.listen(expectAsync1((num result) {
+      expect(result, expected[countA++]);
+    }, count: expected.length));
+    stream.listen(expectAsync1((num result) {
+      expect(result, expected[countB++]);
+    }, count: expected.length));
+  });
+
+  test('rx.Observable.onErrorResumeNext.error.shouldThrow', () async {
+    Stream<num> observableWithError = observable(getErroneousStream())
+        .onErrorResumeNext(getErroneousStream());
+
+    observableWithError.listen((_) {},
+        onError: expectAsync2((dynamic e, dynamic s) {
+          expect(e, isException);
+        }));
+  });
+
+  test('rx.Observable.onErrorResumeNext.pause.resume', () async {
+    StreamSubscription<num> subscription;
+    int count = 0;
+
+    subscription = observable(getErroneousStream())
+        .onErrorResumeNext(_getStream())
+        .listen(expectAsync1((num result) {
+      expect(result, expected[count++]);
+
+      if (count == expected.length) {
+        subscription.cancel();
+      }
+    }, count: expected.length));
+
+    subscription.pause();
+    subscription.resume();
+  });
+
+  test('rx.Observable.onErrorResumeNext.close', () async {
+    int count = 0;
+
+    observable(getErroneousStream())
+        .onErrorResumeNext(_getStream())
+        .listen(expectAsync1((num result) {
+      expect(result, expected[count++]);
+    }, count: expected.length), onDone: expectAsync0(() {
+      // The code should reach this point
+      expect(true, true);
+    }, count: 1));
+  });
+}

--- a/test/transformers/on_error_return_test.dart
+++ b/test/transformers/on_error_return_test.dart
@@ -1,0 +1,47 @@
+import '../test_utils.dart';
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  const num expected = 0;
+
+  test('rx.Observable.onErrorReturn', () async {
+    observable(getErroneousStream())
+        .onErrorReturn(0)
+        .listen(expectAsync1((num result) {
+      expect(result, expected);
+    }));
+  });
+
+  test('rx.Observable.onErrorReturn.asBroadcastStream', () async {
+    Stream<num> stream =
+    observable(getErroneousStream()).onErrorReturn(0).asBroadcastStream();
+
+    expect(stream.isBroadcast, isTrue);
+
+    stream.listen(expectAsync1((num result) {
+      expect(result, expected);
+    }));
+
+    stream.listen(expectAsync1((num result) {
+      expect(result, expected);
+    }));
+  });
+
+  test('rx.Observable.onErrorReturn.pause.resume', () async {
+    StreamSubscription<num> subscription;
+
+    subscription = observable(getErroneousStream())
+        .onErrorReturn(0)
+        .listen(expectAsync1((num result) {
+      expect(result, expected);
+
+      subscription.cancel();
+    }));
+
+    subscription.pause();
+    subscription.resume();
+  });
+}


### PR DESCRIPTION
Another couple operators I've used in RxJava for Android apps, and therefore feel like it's good to include them now!