### PR TITLE
Fail build when formatting is incorrect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 script:
   - set -e
+  - sh tool/check_format.sh
   - pub run test test/rxdart_test.dart

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -47,7 +47,8 @@ import 'transformers/last_where_test.dart' as last_where_test;
 import 'transformers/max_test.dart' as max_test;
 import 'transformers/min_test.dart' as min_test;
 import 'transformers/of_type_test.dart' as of_type_test;
-import 'transformers/on_error_resume_next_test.dart' as on_error_resume_next_test;
+import 'transformers/on_error_resume_next_test.dart'
+    as on_error_resume_next_test;
 import 'transformers/on_error_return_test.dart' as on_error_return_test;
 import 'transformers/reduce_test.dart' as reduce_test;
 import 'transformers/repeat_test.dart' as repeat_test;

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -6,7 +6,8 @@ import 'package:rxdart/rxdart.dart';
 
 Stream<int> get streamA => new Stream<int>.periodic(
     const Duration(milliseconds: 1), (int count) => count).take(3);
-Stream<int> get streamB => new Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
+Stream<int> get streamB =>
+    new Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
 Stream<bool> get streamC {
   final StreamController<bool> controller = new StreamController<bool>()
     ..add(true)
@@ -269,9 +270,9 @@ void main() {
   });
 
   test('rx.Observable.combineLatest.error.shouldThrow.A', () async {
-    Stream<String> observableWithError = Observable.combineLatest4(
-        streamA, streamB, streamC, getErroneousStream(),
-        (int a_value, int b_value, bool c_value, _) {
+    Stream<String> observableWithError = Observable
+        .combineLatest4(streamA, streamB, streamC, getErroneousStream(),
+            (int a_value, int b_value, bool c_value, _) {
       return '$a_value $b_value $c_value $_';
     });
 

--- a/test/streams/empty_test.dart
+++ b/test/streams/empty_test.dart
@@ -10,11 +10,13 @@ void main() {
 
     Stream<int> observable = new Observable<int>.empty();
 
-    observable.listen(expectAsync1((int actual) {
-      onDataCalled = true;
-    }, count: 0), onError: expectAsync2((dynamic e, dynamic s) {
-      onErrorCalled = false;
-    }, count: 0), onDone: expectAsync0(() {
+    observable.listen(
+        expectAsync1((int actual) {
+          onDataCalled = true;
+        }, count: 0),
+        onError: expectAsync2((dynamic e, dynamic s) {
+          onErrorCalled = false;
+        }, count: 0), onDone: expectAsync0(() {
       // We do not expect onData or onError to be called, as empty streams
       // emit no items nor errors
       expect(onDataCalled, isFalse);

--- a/test/streams/tween_test.dart
+++ b/test/streams/tween_test.dart
@@ -111,24 +111,24 @@ void main() {
 
     Observable
         .zip4(
-        Observable.tween(0.0, 100.0, const Duration(seconds: 2),
-            intervalMs: 20),
-        Observable.tween(0.0, 100.0, const Duration(seconds: 2),
-            intervalMs: 20, ease: Ease.IN),
-        Observable.tween(0.0, 100.0, const Duration(seconds: 2),
-            intervalMs: 20, ease: Ease.OUT),
-        Observable.tween(0.0, 100.0, const Duration(seconds: 2),
-            intervalMs: 20, ease: Ease.IN_OUT),
+            Observable.tween(0.0, 100.0, const Duration(seconds: 2),
+                intervalMs: 20),
+            Observable.tween(0.0, 100.0, const Duration(seconds: 2),
+                intervalMs: 20, ease: Ease.IN),
+            Observable.tween(0.0, 100.0, const Duration(seconds: 2),
+                intervalMs: 20, ease: Ease.OUT),
+            Observable.tween(0.0, 100.0, const Duration(seconds: 2),
+                intervalMs: 20, ease: Ease.IN_OUT),
             (double a, double b, double c, double d) => <double>[a, b, c, d])
         .map((List<double> values) =>
-        values.map((double value) => (value * 100).round() / 100))
+            values.map((double value) => (value * 100).round() / 100))
         .listen(expectAsync1((Iterable<double> result) {
-      // test to see if the combined output matches
-      final List<double> expected = expectedValues[count++];
+          // test to see if the combined output matches
+          final List<double> expected = expectedValues[count++];
 
-      for (int i = 0, len = result.length; i < len; i++)
-        expect(expected[i], result.elementAt(i));
-    }, count: expectedValues.length));
+          for (int i = 0, len = result.length; i < len; i++)
+            expect(expected[i], result.elementAt(i));
+        }, count: expectedValues.length));
   });
 
   test('rx.Observable.tween.asBroadcast', () async {

--- a/test/transformers/buffer_with_count_test.dart
+++ b/test/transformers/buffer_with_count_test.dart
@@ -13,8 +13,8 @@ void main() {
     int count = 0;
 
     Stream<List<int>> stream =
-    new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
-        .bufferWithCount(2);
+        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+            .bufferWithCount(2);
 
     stream.listen(expectAsync1((List<int> result) {
       // test to see if the combined output matches

--- a/test/transformers/debounce_test.dart
+++ b/test/transformers/debounce_test.dart
@@ -23,8 +23,8 @@ void main() {
     new Observable<int>(_getStream())
         .debounce(const Duration(milliseconds: 200))
         .listen(expectAsync1((int result) {
-      expect(result, 4);
-    }, count: 1));
+          expect(result, 4);
+        }, count: 1));
   });
 
   test('rx.Observable.debounce.asBroadcastStream', () async {

--- a/test/transformers/flat_map_latest_test.dart
+++ b/test/transformers/flat_map_latest_test.dart
@@ -43,8 +43,8 @@ void main() {
     new Observable<int>(_getStream())
         .flatMapLatest(_getOtherStream)
         .listen(expectAsync1((num result) {
-      expect(result, expectedOutput[count++]);
-    }, count: expectedOutput.length));
+          expect(result, expectedOutput[count++]);
+        }, count: expectedOutput.length));
   });
 
   test('rx.Observable.flatMapLatest.asBroadcastStream', () async {

--- a/test/transformers/flat_map_test.dart
+++ b/test/transformers/flat_map_test.dart
@@ -57,8 +57,8 @@ void main() {
     new Observable<int>(_getStream())
         .flatMap(_getOtherStream)
         .listen(expectAsync1((num result) {
-      expect(expectedOutput[count++], result);
-    }, count: expectedOutput.length));
+          expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
   });
 
   test('rx.Observable.flatMap.asBroadcastStream', () async {

--- a/test/transformers/ignore_elements_test.dart
+++ b/test/transformers/ignore_elements_test.dart
@@ -56,7 +56,7 @@ void main() {
 
   test('rx.Observable.ignoreElements.error.shouldThrow', () async {
     Stream<num> observableWithError =
-    new Observable<num>(getErroneousStream()).ignoreElements();
+        new Observable<num>(getErroneousStream()).ignoreElements();
 
     observableWithError.listen(null,
         onError: expectAsync2((dynamic e, dynamic s) {

--- a/test/transformers/of_type_test.dart
+++ b/test/transformers/of_type_test.dart
@@ -27,16 +27,16 @@ void main() {
     new Observable<dynamic>(_getStream())
         .ofType(new TypeToken<Map<String, int>>())
         .listen(expectAsync1((Map<String, int> result) {
-      expect(result, isMap);
-    }, count: 1));
+          expect(result, isMap);
+        }, count: 1));
   });
 
   test('rx.Observable.ofType.polymorphism', () async {
     new Observable<dynamic>(_getStream())
         .ofType(kNum)
         .listen(expectAsync1((num result) {
-      expect(result is num, true);
-    }, count: 2));
+          expect(result is num, true);
+        }, count: 2));
   });
 
   test('rx.Observable.ofType.asBroadcastStream', () async {

--- a/test/transformers/on_error_resume_next_test.dart
+++ b/test/transformers/on_error_resume_next_test.dart
@@ -17,8 +17,8 @@ void main() {
     observable(getErroneousStream())
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((num result) {
-      expect(result, expected[count++]);
-    }, count: expected.length));
+          expect(result, expected[count++]);
+        }, count: expected.length));
   });
 
   test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
@@ -44,8 +44,8 @@ void main() {
 
     observableWithError.listen((_) {},
         onError: expectAsync2((dynamic e, dynamic s) {
-          expect(e, isException);
-        }));
+      expect(e, isException);
+    }));
   });
 
   test('rx.Observable.onErrorResumeNext.pause.resume', () async {
@@ -55,12 +55,12 @@ void main() {
     subscription = observable(getErroneousStream())
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((num result) {
-      expect(result, expected[count++]);
+          expect(result, expected[count++]);
 
-      if (count == expected.length) {
-        subscription.cancel();
-      }
-    }, count: expected.length));
+          if (count == expected.length) {
+            subscription.cancel();
+          }
+        }, count: expected.length));
 
     subscription.pause();
     subscription.resume();
@@ -69,13 +69,13 @@ void main() {
   test('rx.Observable.onErrorResumeNext.close', () async {
     int count = 0;
 
-    observable(getErroneousStream())
-        .onErrorResumeNext(_getStream())
-        .listen(expectAsync1((num result) {
-      expect(result, expected[count++]);
-    }, count: expected.length), onDone: expectAsync0(() {
-      // The code should reach this point
-      expect(true, true);
-    }, count: 1));
+    observable(getErroneousStream()).onErrorResumeNext(_getStream()).listen(
+        expectAsync1((num result) {
+          expect(result, expected[count++]);
+        }, count: expected.length),
+        onDone: expectAsync0(() {
+          // The code should reach this point
+          expect(true, true);
+        }, count: 1));
   });
 }

--- a/test/transformers/on_error_return_test.dart
+++ b/test/transformers/on_error_return_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   test('rx.Observable.onErrorReturn.asBroadcastStream', () async {
     Stream<num> stream =
-    observable(getErroneousStream()).onErrorReturn(0).asBroadcastStream();
+        observable(getErroneousStream()).onErrorReturn(0).asBroadcastStream();
 
     expect(stream.isBroadcast, isTrue);
 

--- a/test/transformers/sample_test.dart
+++ b/test/transformers/sample_test.dart
@@ -17,8 +17,8 @@ void main() {
     new Observable<int>(_getStream())
         .sample(_getSampleStream())
         .listen(expectAsync1((int result) {
-      expect(expectedOutput[count++], result);
-    }, count: expectedOutput.length));
+          expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
   });
 
   test('rx.Observable.sample.asBroadcastStream', () async {
@@ -49,12 +49,12 @@ void main() {
     subscription = new Observable<int>(_getStream())
         .sample(_getSampleStream())
         .listen(expectAsync1((int result) {
-      expect(expectedOutput[count++], result);
+          expect(expectedOutput[count++], result);
 
-      if (count == expectedOutput.length) {
-        subscription.cancel();
-      }
-    }, count: expectedOutput.length));
+          if (count == expectedOutput.length) {
+            subscription.cancel();
+          }
+        }, count: expectedOutput.length));
 
     subscription.pause();
     subscription.resume();

--- a/test/transformers/take_until_test.dart
+++ b/test/transformers/take_until_test.dart
@@ -37,8 +37,8 @@ void main() {
     new Observable<int>(_getStream())
         .takeUntil(_getOtherStream())
         .listen(expectAsync1((int result) {
-      expect(expectedOutput[count++], result);
-    }, count: expectedOutput.length));
+          expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
   });
 
   test('rx.Observable.takeUntil.asBroadcastStream', () async {
@@ -69,12 +69,12 @@ void main() {
     subscription = new Observable<int>(_getStream())
         .takeUntil(_getOtherStream())
         .listen(expectAsync1((int result) {
-      expect(result, expectedOutput[count++]);
+          expect(result, expectedOutput[count++]);
 
-      if (count == expectedOutput.length) {
-        subscription.cancel();
-      }
-    }, count: expectedOutput.length));
+          if (count == expectedOutput.length) {
+            subscription.cancel();
+          }
+        }, count: expectedOutput.length));
 
     subscription.pause();
     subscription.resume();

--- a/test/transformers/throttle_test.dart
+++ b/test/transformers/throttle_test.dart
@@ -26,8 +26,8 @@ void main() {
     new Observable<int>(_getStream())
         .throttle(const Duration(milliseconds: 250))
         .listen(expectAsync1((int result) {
-      expect(result, expectedOutput[count++]);
-    }, count: 2));
+          expect(result, expectedOutput[count++]);
+        }, count: 2));
   });
 
   test('rx.Observable.throttle.asBroadcastStream', () async {
@@ -58,12 +58,12 @@ void main() {
     subscription = new Observable<int>(_getStream())
         .throttle(const Duration(milliseconds: 250))
         .listen(expectAsync1((int result) {
-      expect(result, expectedOutput[count++]);
+          expect(result, expectedOutput[count++]);
 
-      if (count == expectedOutput.length) {
-        subscription.cancel();
-      }
-    }, count: expectedOutput.length));
+          if (count == expectedOutput.length) {
+            subscription.cancel();
+          }
+        }, count: expectedOutput.length));
 
     subscription.pause();
     subscription.resume();

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -6,12 +6,10 @@ import 'package:test/test.dart';
 import 'package:rxdart/rxdart.dart';
 
 Stream<int> _getStream() => new Stream<int>.periodic(
-    const Duration(milliseconds: 22), (int count) => count)
-  .take(7);
+    const Duration(milliseconds: 22), (int count) => count).take(7);
 
 Stream<int> _getLatestFromStream() => new Stream<int>.periodic(
-    const Duration(milliseconds: 50), (int count) => count)
-  .take(4);
+    const Duration(milliseconds: 50), (int count) => count).take(4);
 
 void main() {
   test('rx.Observable.withLatestFrom', () async {
@@ -29,8 +27,8 @@ void main() {
             (int first, int second) => new Pair(first, second))
         .take(5)
         .listen(expectAsync1((Pair result) {
-      expect(result, expectedOutput[count++]);
-    }, count: expectedOutput.length));
+          expect(result, expectedOutput[count++]);
+        }, count: expectedOutput.length));
   });
 
   test('rx.Observable.withLatestFrom.asBroadcastStream', () async {
@@ -65,12 +63,12 @@ void main() {
             (int first, int second) => new Pair(first, second))
         .take(1)
         .listen(expectAsync1((Pair result) {
-      expect(result, expectedOutput[count++]);
+          expect(result, expectedOutput[count++]);
 
-      if (count == expectedOutput.length) {
-        subscription.cancel();
-      }
-    }, count: expectedOutput.length));
+          if (count == expectedOutput.length) {
+            subscription.cancel();
+          }
+        }, count: expectedOutput.length));
 
     subscription.pause();
     subscription.resume();

--- a/tool/check_format.sh
+++ b/tool/check_format.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Determine which files have been modified and should be run through the formatter
+dart_files=$(git diff --cached --name-only --diff-filter=ACM | grep '.dart$')
+[ -z "$dart_files" ] && exit 0
+
+# Run dartfmt to check if the modified files are properly formatted.
+unformatted=$(dartfmt -n $dart_files)
+[ -z "$unformatted" ] && exit 0
+
+# If the files are not properly formatted. Print message and fail.
+echo >&2 "The following dart files must be formatted with dartfmt. Please run: dartfmt -w ./**/*.dart from the root of the git repository."
+for fn in $unformatted; do
+  echo >&2 "./$fn"
+done
+
+exit 1

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,3 +1,6 @@
+# Ensure the source is formatted
+$(dirname -- "$0")/ensure_dartfmt.sh
+
 # Fast fail the script on failures.
 set -e
 


### PR DESCRIPTION
This addition will cause the Travis build to fail if the PR contains dart files that aren't properly formatted.

Kind of an annoying one haha, but I keep committing unformatted code, and figure it can't hurt to verify that we're keeping our code properly formatted.

It also fixes all the files that were causing failures :)