### PR TITLE
Add `never` factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ var myObservable = observable(myStream);
 - defer
 - just
 - merge
+- never
 - periodic
 - tween
 
@@ -99,7 +100,7 @@ var myObservable = Observable.combineLatest3(
 - groupBy  
 - interval  
 - max  
-- min  
+- min
 - pluck  
 - repeat  
 - retry  

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -6,6 +6,7 @@ import 'package:rxdart/src/streams/concat.dart';
 import 'package:rxdart/src/streams/concat_eager.dart';
 import 'package:rxdart/src/streams/defer.dart';
 import 'package:rxdart/src/streams/merge.dart';
+import 'package:rxdart/src/streams/never.dart';
 import 'package:rxdart/src/streams/tween.dart';
 import 'package:rxdart/src/streams/zip.dart';
 
@@ -291,6 +292,16 @@ class Observable<T> extends Stream<T> {
   /// http://rxmarbles.com/#merge
   factory Observable.merge(Iterable<Stream<T>> streams) =>
       new Observable<T>(new MergeStream<T>(streams));
+
+  /// Returns a non-terminating observable sequence, which can be used to denote
+  /// an infinite duration.
+  ///
+  /// The never operator is one with very specific and limited behavior. These
+  /// are useful for testing purposes, and sometimes also for combining with
+  /// other Observables or as parameters to operators that expect other
+  /// Observables as parameters.
+  factory Observable.never() =>
+      new Observable<T>(new NeverStream<T>());
 
   /// Creates an Observable that repeatedly emits events at [period] intervals.
   ///

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+/// Returns a non-terminating observable sequence, which can be used to denote
+/// an infinite duration.
+///
+/// The never operator is one with very specific and limited behavior. These
+/// are useful for testing purposes, and sometimes also for combining with
+/// other Observables or as parameters to operators that expect other
+/// Observables as parameters.
+class NeverStream<T> extends Stream<T> {
+  NeverStream();
+
+  @override
+  StreamSubscription<T> listen(void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+
+    // ignore: close_sinks
+    StreamController<T> controller = new StreamController<T>();
+
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+}

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -6,5 +6,6 @@ export 'package:rxdart/src/streams/concat.dart';
 export 'package:rxdart/src/streams/concat_eager.dart';
 export 'package:rxdart/src/streams/defer.dart';
 export 'package:rxdart/src/streams/merge.dart';
+export 'package:rxdart/src/streams/never.dart';
 export 'package:rxdart/src/streams/tween.dart';
 export 'package:rxdart/src/streams/zip.dart';

--- a/test/streams/never_test.dart
+++ b/test/streams/never_test.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:rxdart/src/streams/never.dart';
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('NeverStream', () async {
+    bool onDataCalled = false;
+    bool onDoneCalled = false;
+    bool onErrorCalled = false;
+
+    Stream<int> stream = new NeverStream<int>();
+
+    StreamSubscription<int> subscription = stream.listen(
+        expectAsync1((int actual) {
+          onDataCalled = true;
+        }, count: 0),
+        onError: expectAsync2((dynamic e, dynamic s) {
+          onErrorCalled = false;
+        }, count: 0), onDone: expectAsync0(() {
+      onDataCalled = true;
+    }, count: 0));
+
+    await new Future<int>.delayed(new Duration(milliseconds: 10));
+
+    await subscription.cancel();
+
+    // We do not expect onData, onDone, nor onError to be called, as [never]
+    // streams emit no items or errors, and they do not terminate
+    expect(onDataCalled, isFalse);
+    expect(onDoneCalled, isFalse);
+    expect(onErrorCalled, isFalse);
+  });
+
+  test('rx.Observable.never', () async {
+    bool onDataCalled = false;
+    bool onDoneCalled = false;
+    bool onErrorCalled = false;
+
+    Observable<int> observable = new Observable<int>.never();
+
+    StreamSubscription<int> subscription = observable.listen(
+        expectAsync1((int actual) {
+          onDataCalled = true;
+        }, count: 0),
+        onError: expectAsync2((dynamic e, dynamic s) {
+          onErrorCalled = false;
+        }, count: 0), onDone: expectAsync0(() {
+      onDataCalled = true;
+    }, count: 0));
+
+    await new Future<int>.delayed(new Duration(milliseconds: 10));
+
+    await subscription.cancel();
+
+    // We do not expect onData, onDone, nor onError to be called, as [never]
+    // streams emit no items or errors, and they do not terminate
+    expect(onDataCalled, isFalse);
+    expect(onDoneCalled, isFalse);
+    expect(onErrorCalled, isFalse);
+  });
+}

--- a/test/transformers/call_test.dart
+++ b/test/transformers/call_test.dart
@@ -1,5 +1,4 @@
 import '../test_utils.dart';
-import 'dart:async';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test/test.dart';
 import 'package:rxdart/rxdart.dart';
@@ -143,7 +142,7 @@ void main() {
       // in order to "fail fast" and alert the developer that the operator
       // can be used or safely removed.
       observable.call();
-    } catch (e, s) {
+    } catch (e) {
       expect(e is AssertionError, isTrue);
     }
   });


### PR DESCRIPTION
Implements the never factory from ReactiveX (http://reactivex.io/documentation/operators/empty-never-throw.html).

Not sure the best way to test this one, as it uh, should do anything haha... 
