### PR TITLE
added count operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ var myObservable = Observable.combineLatest3(
 ##### Available Methods
 - bufferWithCount
 - call
+- count
 - debounce  
 - flatMapLatest  
 - flatMap  

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -13,6 +13,7 @@ import 'package:rxdart/src/streams/zip.dart';
 
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 import 'package:rxdart/src/transformers/call.dart';
+import 'package:rxdart/src/transformers/count.dart';
 import 'package:rxdart/src/transformers/debounce.dart';
 import 'package:rxdart/src/transformers/default_if_empty.dart';
 import 'package:rxdart/src/transformers/flat_map.dart';
@@ -313,8 +314,7 @@ class Observable<T> extends Stream<T> {
   /// are useful for testing purposes, and sometimes also for combining with
   /// other Observables or as parameters to operators that expect other
   /// Observables as parameters.
-  factory Observable.never() =>
-      new Observable<T>(new NeverStream<T>());
+  factory Observable.never() => new Observable<T>(new NeverStream<T>());
 
   /// Creates an Observable that repeatedly emits events at [period] intervals.
   ///
@@ -682,6 +682,17 @@ class Observable<T> extends Stream<T> {
           onListen: onListen,
           onPause: onPause,
           onResume: onResume));
+
+  /// Returns an observable sequence containing a value that represents
+  /// how many elements in the specified observable sequence satisfy
+  /// a condition if provided, else the count of items.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable(['a', 'b', 'c']).count(); // Prints: 3
+  ///     new Observable.fromIterable(['a', 'b', 'c']).count((char) => char == 'a'); // Prints: 1
+  Observable<int> count([bool predicate(T event)]) =>
+      transform(countTransformer(predicate));
 
   @override
   Future<bool> contains(Object needle) => stream.contains(needle);

--- a/lib/src/transformers/count.dart
+++ b/lib/src/transformers/count.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+StreamTransformer<T, int> countTransformer<T>([bool predicate(T event)]) {
+  int _index = 0;
+
+  predicate ??= (T event) => true;
+
+  return new StreamTransformer<T, int>.fromHandlers(
+      handleData: (T data, EventSink<int> sink) {
+    if (predicate(data)) sink.add(++_index);
+  });
+}

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -22,6 +22,7 @@ import 'transformers/async_expand_test.dart' as async_expand_test;
 import 'transformers/async_map_test.dart' as async_map_test;
 import 'transformers/buffer_with_count_test.dart' as buffer_with_count_test;
 import 'transformers/call_test.dart' as call_test;
+import 'transformers/count_test.dart' as count_test;
 import 'transformers/contains_test.dart' as contains_test;
 import 'transformers/debounce_test.dart' as debounce_test;
 import 'transformers/default_if_empty_test.dart' as default_if_empty_test;
@@ -100,6 +101,7 @@ void main() {
   async_map_test.main();
   buffer_with_count_test.main();
   call_test.main();
+  count_test.main();
   contains_test.main();
   debounce_test.main();
   default_if_empty_test.main();

--- a/test/transformers/count_test.dart
+++ b/test/transformers/count_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('rx.Observable.count.noPredicate', () async {
+    const List<int> expectedOutput = const <int>[1, 2, 3];
+    int count = 0;
+
+    new Observable<String>(
+            new Stream<String>.fromIterable(<String>['a', 'b', 'c']))
+        .count()
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.count.withPredicate', () async {
+    new Observable<String>(
+            new Stream<String>.fromIterable(<String>['a', 'b', 'c']))
+        .count((String char) => char == 'b')
+        .listen(expectAsync1((int result) {
+      expect(1, result);
+    }));
+  });
+
+  test('rx.Observable.count.asBroadcastStream', () async {
+    Stream<int> stream = new Observable<String>(
+            new Stream<String>.fromIterable(<String>['a', 'b', 'c'])
+                .asBroadcastStream())
+        .count();
+
+    // listen twice on same stream
+    stream.listen((_) {});
+    stream.listen((_) {});
+    // code should reach here
+    expect(true, true);
+  });
+
+  test('rx.Observable.count.error.shouldThrow', () async {
+    Stream<int> observableWithError =
+        new Observable<num>(new ErrorStream<num>(new Exception())).count();
+
+    observableWithError.listen(null, onError: (dynamic e, dynamic s) {
+      expect(e, isException);
+    });
+  });
+
+  test('rx.Observable.count.error.predicate', () async {
+    Stream<int> observableWithError =
+        new Observable<ErrorComparator>.fromIterable(
+                <ErrorComparator>[new ErrorComparator(), new ErrorComparator()])
+            .count((ErrorComparator error) => throw new Exception());
+
+    observableWithError.listen((_) {}, onError: (dynamic e, dynamic s) {
+      expect(e, isException);
+    });
+  });
+}
+
+class ErrorComparator implements Comparable<ErrorComparator> {
+  @override
+  int compareTo(ErrorComparator other) {
+    throw new Exception();
+  }
+}


### PR DESCRIPTION
count simply returns an `int` value representing the amount of events emitted by the `Observable`.

You can optionally provide a `predicate` to filter results,
for example say you have an `Observable` emitting values randomly between 0 and 10,
if you only need to keep track of how many items are above 9, you can pass the following `predicate`:

`stream.count((double value) => value > 9.0);`

If you pass no predicate, every event will be counted, for example

```
new Observable.fromIterable(['a', 'b', 'c'])
    .count()
    .listen((int count) => print('count: $count'));
/// 1
/// 2
/// 3
```