### PR TITLE
Add `concatMap` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ var myObservable = Observable.combineLatest3(
 ##### Available Methods
 - bufferWithCount
 - call
-- debounce  
-- flatMapLatest  
-- flatMap  
-- groupBy  
+- concatMap
+- debounce
+- flatMapLatest
+- flatMap
+- groupBy
 - interval  
 - max  
 - min

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -13,6 +13,7 @@ import 'package:rxdart/src/streams/zip.dart';
 
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 import 'package:rxdart/src/transformers/call.dart';
+import 'package:rxdart/src/transformers/concat_map.dart';
 import 'package:rxdart/src/transformers/debounce.dart';
 import 'package:rxdart/src/transformers/default_if_empty.dart';
 import 'package:rxdart/src/transformers/flat_map.dart';
@@ -313,8 +314,7 @@ class Observable<T> extends Stream<T> {
   /// are useful for testing purposes, and sometimes also for combining with
   /// other Observables or as parameters to operators that expect other
   /// Observables as parameters.
-  factory Observable.never() =>
-      new Observable<T>(new NeverStream<T>());
+  factory Observable.never() => new Observable<T>(new NeverStream<T>());
 
   /// Creates an Observable that repeatedly emits events at [period] intervals.
   ///
@@ -682,6 +682,17 @@ class Observable<T> extends Stream<T> {
           onListen: onListen,
           onPause: onPause,
           onResume: onResume));
+
+  /// Maps each emitted item to a new [Stream] using the given predicate, then
+  /// subscribes to each new stream one after the next until all values are
+  /// emitted.
+  ///
+  /// ConcatMap is similar to flatMap, but ensures order by guaranteeing that
+  /// all items from the created stream will be emitted before moving to the
+  /// next created stream. This process continues until all created streams have
+  /// completed.
+  Observable<S> concatMap<S>(Stream<S> predicate(T value)) =>
+      transform(concatMapTransformer(predicate));
 
   @override
   Future<bool> contains(Object needle) => stream.contains(needle);

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -13,7 +13,6 @@ class NeverStream<T> extends Stream<T> {
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-
     // ignore: close_sinks
     StreamController<T> controller = new StreamController<T>();
 

--- a/lib/src/transformers/concat_map.dart
+++ b/lib/src/transformers/concat_map.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+/// Maps each emitted item to a new [Stream] using the given predicate, then
+/// subscribes to each new stream one after the next until all values are
+/// emitted.
+///
+/// ConcatMap is similar to flatMap, but ensures order by guaranteeing that
+/// all items from the created stream will be emitted before moving to the
+/// next created stream. This process continues until all created streams have
+/// completed.
+StreamTransformer<T, S> concatMapTransformer<T, S>(
+    Stream<S> predicate(T value)) {
+  return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    final List<Stream<S>> streams = <Stream<S>>[];
+    final List<bool> completionStatuses = <bool>[];
+    StreamSubscription<S> currentSubscription;
+    StreamController<S> controller;
+    StreamSubscription<T> subscription;
+    bool isParentSubscriptionDone = false;
+    int index = 0;
+
+    void moveNext() {
+      final int currentIndex = index;
+
+      if (currentSubscription == null && streams[currentIndex] != null) {
+        currentSubscription = streams[currentIndex].listen(
+            (S value) {
+              controller.add(value);
+            },
+            onError: controller.addError,
+            onDone: () {
+              completionStatuses[currentIndex] = true;
+              currentSubscription.cancel();
+              currentSubscription = null;
+
+              if (completionStatuses.every((bool isComplete) => isComplete) &&
+                  isParentSubscriptionDone) {
+                controller.close();
+              } else {
+                moveNext();
+              }
+            });
+
+        index += 1;
+      }
+    }
+
+    controller = new StreamController<S>(
+        sync: true,
+        onListen: () {
+          subscription = input.listen(
+              (T value) {
+                streams.add(predicate(value));
+                completionStatuses.add(false);
+
+                moveNext();
+              },
+              onError: controller.addError,
+              onDone: () {
+                isParentSubscriptionDone = true;
+              },
+              cancelOnError: cancelOnError);
+        },
+        onPause: ([Future<dynamic> resumeSignal]) {
+          subscription.pause(resumeSignal);
+
+          currentSubscription?.pause(resumeSignal);
+        },
+        onResume: () {
+          subscription.resume();
+
+          currentSubscription?.resume();
+        },
+        onCancel: () {
+          final List<Future<dynamic>> list = <Future<dynamic>>[
+            subscription.cancel()
+          ];
+
+          if (currentSubscription != null) {
+            list.add(currentSubscription.cancel());
+          }
+
+          return Future.wait(list
+              .where((Future<dynamic> cancelFuture) => cancelFuture != null));
+        });
+
+    return controller.stream.listen(null);
+  });
+}

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -1,6 +1,7 @@
 library rx_transformers;
 
 export 'package:rxdart/src/transformers/buffer_with_count.dart';
+export 'package:rxdart/src/transformers/concat_map.dart';
 export 'package:rxdart/src/transformers/debounce.dart';
 export 'package:rxdart/src/transformers/default_if_empty.dart';
 export 'package:rxdart/src/transformers/flat_map.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -22,6 +22,7 @@ import 'transformers/async_expand_test.dart' as async_expand_test;
 import 'transformers/async_map_test.dart' as async_map_test;
 import 'transformers/buffer_with_count_test.dart' as buffer_with_count_test;
 import 'transformers/call_test.dart' as call_test;
+import 'transformers/concat_map_test.dart' as concat_map_test;
 import 'transformers/contains_test.dart' as contains_test;
 import 'transformers/debounce_test.dart' as debounce_test;
 import 'transformers/default_if_empty_test.dart' as default_if_empty_test;
@@ -100,6 +101,7 @@ void main() {
   async_map_test.main();
   buffer_with_count_test.main();
   call_test.main();
+  concat_map_test.main();
   contains_test.main();
   debounce_test.main();
   default_if_empty_test.main();

--- a/test/streams/never_test.dart
+++ b/test/streams/never_test.dart
@@ -18,9 +18,10 @@ void main() {
         }, count: 0),
         onError: expectAsync2((dynamic e, dynamic s) {
           onErrorCalled = false;
-        }, count: 0), onDone: expectAsync0(() {
-      onDataCalled = true;
-    }, count: 0));
+        }, count: 0),
+        onDone: expectAsync0(() {
+          onDataCalled = true;
+        }, count: 0));
 
     await new Future<int>.delayed(new Duration(milliseconds: 10));
 
@@ -46,9 +47,10 @@ void main() {
         }, count: 0),
         onError: expectAsync2((dynamic e, dynamic s) {
           onErrorCalled = false;
-        }, count: 0), onDone: expectAsync0(() {
-      onDataCalled = true;
-    }, count: 0));
+        }, count: 0),
+        onDone: expectAsync0(() {
+          onDataCalled = true;
+        }, count: 0));
 
     await new Future<int>.delayed(new Duration(milliseconds: 10));
 

--- a/test/transformers/concat_map_test.dart
+++ b/test/transformers/concat_map_test.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('rx.Observable.concatMap', () async {
+    const List<int> expectedOutput = const <int>[1, 1, 2, 2, 3, 3];
+    int count = 0;
+
+    new Observable<int>(_getStream()).concatMap(_getOtherStream).listen(
+        expectAsync1((num result) {
+          expect(result, expectedOutput[count++]);
+        }, count: expectedOutput.length), onDone: expectAsync0(() {
+      expect(true, true);
+    }));
+  });
+
+  test('rx.Observable.concatMap.asBroadcastStream', () async {
+    Stream<num> stream = new Observable<int>(_getStream())
+        .concatMap(_getOtherStream)
+        .asBroadcastStream();
+
+    // listen twice on same stream
+    stream.listen((_) {});
+    stream.listen((_) {});
+    // code should reach here
+    expect(stream.isBroadcast, isTrue);
+  });
+
+  test('rx.Observable.concatMap.error.shouldThrow', () async {
+    Stream<num> observableWithError =
+        new Observable<num>(new ErrorStream<num>(new Exception()))
+            .concatMap(_getOtherStream);
+
+    observableWithError.listen(null, onError: (dynamic e, dynamic s) {
+      expect(e, isException);
+    });
+  });
+
+  test('rx.Observable.concatMap.pause.resume', () async {
+    StreamSubscription<int> subscription;
+    Observable<int> stream = new Observable<int>.just(0)
+        .concatMap((_) => new Observable<int>.just(1));
+
+    subscription = stream.listen(expectAsync1((int value) {
+      expect(value, 1);
+      subscription.cancel();
+    }, count: 1));
+
+    new Timer(new Duration(milliseconds: 10), () {
+      subscription.pause();
+      subscription.resume();
+    });
+  });
+
+  test('rx.Observable.concatMap.cancel', () async {
+    StreamSubscription<num> subscription;
+    Observable<num> stream =
+        new Observable<num>(_getStream()).concatMap(_getOtherStream);
+
+    // Cancel the subscription before any events come through
+    subscription = stream.listen(
+        expectAsync1((num value) {
+          expect(true, isFalse);
+        }, count: 0),
+        onError: expectAsync2((dynamic e, dynamic s) {
+          expect(true, isFalse);
+        }, count: 0),
+        onDone: expectAsync0(() {
+          expect(true, isFalse);
+        }, count: 0));
+
+    new Timer(new Duration(milliseconds: 5), () {
+      subscription.cancel();
+    });
+  });
+}
+
+Stream<int> _getStream() {
+  return new Stream<int>.fromIterable(<int>[1, 2, 3]);
+}
+
+Stream<num> _getOtherStream(num value) {
+  StreamController<num> controller = new StreamController<num>();
+
+  new Timer(
+      // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer
+      // than it delays 3
+      new Duration(milliseconds: value == 1 ? 20 : value == 2 ? 10 : 5), () {
+    controller.add(value);
+  });
+
+  // Delay by a longer amount, with the same reversing effect
+  new Timer(new Duration(milliseconds: value == 1 ? 30 : value == 2 ? 20 : 10),
+      () {
+    controller.add(value);
+    controller.close();
+  });
+
+  return controller.stream;
+}

--- a/test/transformers/flat_map_test.dart
+++ b/test/transformers/flat_map_test.dart
@@ -4,27 +4,17 @@ import 'package:test/test.dart';
 import 'package:rxdart/rxdart.dart';
 
 Stream<int> _getStream() {
-  StreamController<int> controller = new StreamController<int>();
-
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
-    controller.add(4);
-    controller.close();
-  });
-
-  return controller.stream;
+  return new Stream<int>.fromIterable(<int>[1, 2, 3]);
 }
 
 Stream<num> _getOtherStream(num value) {
   StreamController<num> controller = new StreamController<num>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(value + 1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(value + 2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(value + 3));
-  new Timer(const Duration(milliseconds: 400), () {
-    controller.add(value + 4);
+  new Timer(
+      // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer
+      // than they delay 3
+      new Duration(milliseconds: value == 1 ? 15 : value == 2 ? 10 : 5), () {
+    controller.add(value);
     controller.close();
   });
 
@@ -33,30 +23,13 @@ Stream<num> _getOtherStream(num value) {
 
 void main() {
   test('rx.Observable.flatMap', () async {
-    const List<int> expectedOutput = const <int>[
-      2,
-      3,
-      3,
-      4,
-      4,
-      4,
-      5,
-      5,
-      5,
-      5,
-      6,
-      6,
-      6,
-      7,
-      7,
-      8
-    ];
+    const List<int> expectedOutput = const <int>[3, 2, 1];
     int count = 0;
 
     new Observable<int>(_getStream())
         .flatMap(_getOtherStream)
         .listen(expectAsync1((num result) {
-          expect(expectedOutput[count++], result);
+          expect(result, expectedOutput[count++]);
         }, count: expectedOutput.length));
   });
 


### PR DESCRIPTION
We've got flatMap, but we're missing concatMap! http://reactivex.io/documentation/operators/concat.html

This is similar to flatMap, but just a *bit* different, in that it doesn't subscribe to each newly created observable right away, but rather moves from one subscription to the next, in the same way `concat` does.

